### PR TITLE
Add exports + events

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,34 @@ If you need to contact JG Scripts; email: hello@jgscripts.com
 ```
 
 ```
+### CLIENT SIDE EXPORTS:
+
+```lua
+-- Get the stress level of the player that uses it, returns integer 0-100
+exports['jg-stress-addon']:getStress()
+
+-- gain stress level
+-- amount = int 0-100
+exports['jg-stress-addon']:gainStress(amount)
+
+-- returns boolean (true/false)
+exports['jg-stress-addon']:isPlayerJobWhitelisted()
+
+-- sets player who called it stress to 0
+exports['jg-stress-addon']:resetStress() 
+
+-- Sets a player stress value to a specific value
+exports['jg-stress-addon']:setStressLevel(amount)
+```
+
+### SERVER SIDE EVENTS
+
+```lua
+---@param amount integer  
+TriggerServerEvent('hud:server:RelieveStress', amount)
+```
+
+```lua
+---@param amount integer
+TriggerServerEvent('hud:server:GainStress', amount)
+```

--- a/client.lua
+++ b/client.lua
@@ -243,3 +243,30 @@ CreateThread(function()
     Wait(effectInterval)
   end
 end)
+
+local function resetStress()
+  DebugPrint('Resetting stress to 0')
+  LocalPlayer.state:set('stress', 0, true)
+end
+
+local function SetStressLevel(amount)
+  if amount < 0 then amount = 0 end
+  if amount > 100 then amount = 100 end
+  DebugPrint('Setting stress level to: %s', amount)
+  LocalPlayer.state:set('stress', amount, true)
+end
+
+
+-- This will have to be use as exports['jg-stress-addon']:getStress
+exports('getStress', getStress)
+-- This will have to be use as exports['jg-stress-addon']:gainStress(amount)
+exports('gainStress', gainStress)
+-- This will have to be use as exports['jg-stress-addon']:isJobWhitelisted()
+exports('isJobWhitelisted', isJobWhitelisted)
+-- This will have to be use as exports['jg-stress-addon']:resetStress() 
+exports('resetStress', resetStress)
+
+-- This will have to be use as exports['jg-stress-addon']:setStressLevel(amount)
+exports('setStressLevel', SetStressLevel)
+
+-- THIS HAS NOT BEEN TESTED

--- a/client.lua
+++ b/client.lua
@@ -2,7 +2,7 @@ local Config = lib.load('config')
 
 local function DebugPrint(fmt, ...)
   if Config.Debug then
-    lib.print.debug(string.format(fmt, ...))
+    print('[DEBUG]' .. string.format(fmt, ...))
   end
 end
 
@@ -262,7 +262,7 @@ exports('getStress', getStress)
 -- This will have to be use as exports['jg-stress-addon']:gainStress(amount)
 exports('gainStress', gainStress)
 -- This will have to be use as exports['jg-stress-addon']:isJobWhitelisted()
-exports('isJobWhitelisted', isJobWhitelisted)
+exports('isPlayerJobWhitelisted', isJobWhitelisted)
 -- This will have to be use as exports['jg-stress-addon']:resetStress() 
 exports('resetStress', resetStress)
 

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,7 +4,7 @@ lua54 'yes'
 use_experimental_fxv2_oal 'yes'
 
 description 'For support or other queries: discord.gg/jgscripts'
-version '1.3'
+version '1.4'
 repository 'https://github.com/jgscripts/jg-stress-addon'
 
 client_script 'client.lua'

--- a/server.lua
+++ b/server.lua
@@ -1,6 +1,6 @@
 local resetStress = false
 local Config = lib.load('config')
---[[ RegisterNetEvent('hud:server:GainStress', function(amount)
+RegisterNetEvent('hud:server:GainStress', function(amount)
     local src = source
     local player = exports.qbx_core:GetPlayer(src)
     local newStress
@@ -20,8 +20,7 @@ local Config = lib.load('config')
     end
 
     Player(src)?.state:set('stress', newStress, true)
-    -- exports.qbx_core:Notify(src, locale('notify.stress_gain'), 'inform', 2500, nil, nil, {'#141517', '#ffffff'}, 'brain', '#C53030')
-end) ]]
+end)
 
 local function getStress(src)
   return Player(src)?.state?.stress or 0


### PR DESCRIPTION
This pull request introduces new client-side exports and server-side events for the stress system, making it easier for other resources to interact with player stress levels. It also cleans up debug logging and refactors some event handling for clarity and usability.

**Stress system API improvements:**

* Added multiple client-side exports in `client.lua` to allow other scripts to get, set, reset, and modify player stress levels, as well as check job whitelist status. These are documented in the updated `README.md`. [[1]](diffhunk://#diff-bd3d5f0dfcec5f757b1cb2b6ec16fd75bb5ead988fed33033896aaf1a00e4a0dR246-R272) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R47-R77)
* Introduced new server-side events (`hud:server:GainStress` and `hud:server:RelieveStress`) for gaining and relieving stress, with usage examples added to the documentation.

**Codebase cleanup and refactoring:**

* Simplified debug logging in `client.lua` to use standard print statements instead of the library's debug print.
* Refactored the server event registration in `server.lua` by removing unnecessary comment blocks and unused code. [[1]](diffhunk://#diff-1b8f97d898e63162c92a0f09152d067cbe6a053a3fe5d96b96d751cbacce5786L3-R3) [[2]](diffhunk://#diff-1b8f97d898e63162c92a0f09152d067cbe6a053a3fe5d96b96d751cbacce5786L23-R23)


Thank god for copilot amen