### PR TITLE
Fix stress tracking bugs and tighten config

### DIFF
--- a/client/vehicle.lua
+++ b/client/vehicle.lua
@@ -11,7 +11,7 @@ return function(gainStress, isJobWhitelisted, speedMultiplier, Config)
 
           if vehClass ~= 13 and vehClass ~= 14 and vehClass ~= 15 and vehClass ~= 16 and vehClass ~= 21 then
             local hasSeatbelt = LocalPlayer.state?.seatbelt
-            local stressSpeed = (vehClass == 8 or hasSeatbelt) and Config.Stress.minForSpeeding or Config.Stress.minForSpeedingUnbuckled
+            local stressSpeed = (vehClass == 8 or hasSeatbelt) and Config.Stress.speedThresholdBuckled or Config.Stress.speedThresholdUnbuckled
             if speed >= stressSpeed then
               DebugPrint('Speed exceeded threshold (%.2f), applying stress', stressSpeed)
               gainStress(math.random(1, 3))

--- a/config/config.lua
+++ b/config/config.lua
@@ -1,30 +1,33 @@
 return {
 
-Debug = false, -- Loads of prints in F8 
+Debug = false, -- Loads of prints in F8
 UseMPH = false, -- Use MPH instead of KPH
 
 Stress = {
   chance = 0.1, -- Percentage stress chance when shooting (0-1)
   minForShaking = 50, -- Minimum stress level for screen shaking
-  minForSpeeding = 1000, -- Minimum stress level for speeding while buckled (works with JG HUD seatbelt)
-  minForSpeedingUnbuckled = 50, -- Minimum stress level for speeding while unbuckled (works with JG HUD seatbelt)
+  speedThresholdBuckled = 1000, -- Speed threshold (in KPH/MPH per Config.UseMPH) above which buckled driving causes stress
+        speedThresholdUnbuckled = 50, -- Speed threshold (in KPH/MPH per Config.UseMPH) above which unbuckled driving causes stress
+    disableForLEO = false, -- If true, players whose job.type == 'leo' gain no stress (QB/QBX only. ESX has no job.type)
     whitelistedWeapons = { -- Weapons which don't give stress
       `weapon_petrolcan`, -- Please use backticks (`) not quotes ('/')
       `weapon_hazardcan`,
       `weapon_fireextinguisher`,
     },
-    blurIntensity = { -- Blur intensity for different stress levels
-      [1] = {min = 50, max = 60, intensity = 1500},
-      [2] = {min = 60, max = 70, intensity = 2000},
-      [3] = {min = 70, max = 80, intensity = 2500},
-      [4] = {min = 80, max = 90, intensity = 2700},
+    blurIntensity = { -- Blur intensity for different stress levels (ranges are inclusive on both ends)
+      [1] = {min = 50, max = 59, intensity = 1500},
+      [2] = {min = 60, max = 69, intensity = 2000},
+      [3] = {min = 70, max = 79, intensity = 2500},
+      [4] = {min = 80, max = 89, intensity = 2700},
       [5] = {min = 90, max = 100, intensity = 3000},
     },
-    effectInterval = { -- Effect interval for different stress levels
-      [1] = {min = 50, max = 60, timeout = math.random(50000, 60000)},
-      [2] = {min = 60, max = 70, timeout = math.random(40000, 50000)},
-      [3] = {min = 70, max = 80, timeout = math.random(30000, 40000)},
-      [4] = {min = 80, max = 90, timeout = math.random(20000, 30000)},
+    -- Effect interval for different stress levels (ranges are inclusive on both ends).
+    -- The timeout values are rolled once at resource start via math.random and stay fixed per server boot.
+    effectInterval = {
+      [1] = {min = 50, max = 59, timeout = math.random(50000, 60000)},
+      [2] = {min = 60, max = 69, timeout = math.random(40000, 50000)},
+      [3] = {min = 70, max = 79, timeout = math.random(30000, 40000)},
+      [4] = {min = 80, max = 89, timeout = math.random(20000, 30000)},
       [5] = {min = 90, max = 100, timeout = math.random(15000, 20000)},
     },
 },

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,7 +4,7 @@ lua54 'yes'
 use_experimental_fxv2_oal 'yes'
 description 'For support or other queries: discord.gg/jgscripts'
 repository 'https://github.com/jgscripts/jg-stress-addon'
-version '2.0.1'
+version '2.0.2'
 
 client_scripts {
   'client/init.lua',

--- a/server/server.lua
+++ b/server/server.lua
@@ -1,55 +1,18 @@
 local resetStress = false
 local Config = lib.require('config.config')
 
-RegisterNetEvent('hud:server:GainStress', function(amount)
-    local src = source
-    local player = GetPlayer(src)
-    local newStress
-    
-    if not player or (Config.stress.disableForLEO and player.PlayerData.job.type == 'leo') then return end
-    if not resetStress then
-      if not player.PlayerData.metadata.stress then
-        player.PlayerData.metadata.stress = 0
-      end
-      newStress = player.PlayerData.metadata.stress + amount
-      if newStress <= 0 then newStress = 0 end
-    else
-      newStress = 0
-    end
-    if newStress > 100 then
-      newStress = 100
-    end
-
-    Player(src)?.state:set('stress', newStress, true)
-end)
-
 local function getStress(src)
   return Player(src)?.state?.stress or 0
 end
 
-RegisterNetEvent('updateStress', function(newStress)
-  local src = source
-  if not newStress then return end
-  
-  if newStress < 0 then newStress = 0 end
-  if newStress > 100 then newStress = 100 end
-  
-  local player = Player(src)
+local function gainStress(src, amount)
+  local player = GetPlayer(src)
   if not player then return end
-  
-  player.state:set('stress', newStress, true)
-end)
+  if Config.Stress.disableForLEO and player.PlayerData.job?.type == 'leo' then return end
 
-RegisterNetEvent('hud:server:RelieveStress', function(amount)
-  local src = source
-  local stress = getStress(src)
   local newStress
-
   if not resetStress then
-    if not stress then
-      stress = 0
-    end
-    newStress = stress - amount
+    newStress = getStress(src) + amount
     if newStress <= 0 then newStress = 0 end
   else
     newStress = 0
@@ -57,19 +20,46 @@ RegisterNetEvent('hud:server:RelieveStress', function(amount)
   if newStress > 100 then
     newStress = 100
   end
-  
-  Player(src).state:set('stress', newStress, true)
-  -- exports.qbx_core:Notify(src, locale('notify.stress_removed'), 'inform', 2500, nil, nil, {'#141517', '#ffffff'}, 'brain', '#0F52BA')
+
+  Player(src)?.state:set('stress', newStress, true)
+end
+
+local function relieveStress(src, amount)
+  local newStress
+  if not resetStress then
+    newStress = getStress(src) - amount
+    if newStress <= 0 then newStress = 0 end
+  else
+    newStress = 0
+  end
+  if newStress > 100 then
+    newStress = 100
+  end
+
+  Player(src)?.state:set('stress', newStress, true)
+end
+
+RegisterNetEvent('hud:server:GainStress', function(amount)
+  gainStress(source, amount)
 end)
 
-exports('relieveStress', function(src, amount)
-  TriggerEvent('hud:server:RelieveStress', src, amount)
+RegisterNetEvent('hud:server:RelieveStress', function(amount)
+  relieveStress(source, amount)
 end)
 
-exports('gainStress', function(src, amount)
-  TriggerEvent('hud:server:GainStress', src, amount)
+RegisterNetEvent('updateStress', function(newStress)
+  local src = source
+  if not newStress then return end
+
+  if newStress < 0 then newStress = 0 end
+  if newStress > 100 then newStress = 100 end
+
+  local player = Player(src)
+  if not player then return end
+
+  player.state:set('stress', newStress, true)
 end)
 
-exports('getStress', function(src)
-  return getStress(src)
-end)
+exports('relieveStress', relieveStress)
+exports('gainStress', gainStress)
+exports('getStress', getStress)

--- a/shared/utils.lua
+++ b/shared/utils.lua
@@ -1,6 +1,6 @@
-local Config = lib.load('config.config')
+local Config = lib.require('config.config')
 
-function InitFramework()
+local function resolveFramework()
     if GetResourceState('qbx_core') == 'started' then
         return 'qbx'
     elseif GetResourceState('qb-core') == 'started' then
@@ -12,6 +12,12 @@ function InitFramework()
     end
 end
 
+local framework = resolveFramework()
+
+function InitFramework()
+    return framework
+end
+
 function DebugPrint(fmt, ...)
     if Config.Debug then
         print('[DEBUG]' .. string.format(fmt, ...))
@@ -19,12 +25,11 @@ function DebugPrint(fmt, ...)
 end
 
 function GetPlayer(src)
-    local fw = InitFramework()
-    if fw == 'qbx' then
+    if framework == 'qbx' then
         return exports.qbx_core:GetPlayer(src)
-    elseif fw == 'qb' then
+    elseif framework == 'qb' then
         return exports['qb-core']:GetPlayer(src)
-    elseif fw == 'esx' then
+    elseif framework == 'esx' then
         local ESX = exports.es_extended:getSharedObject()
         return ESX.GetPlayerFromId(src)
     else


### PR DESCRIPTION
server/server.lua:
- Fix crash on Config.stress.disableForLEO (wrong casing; Config.Stress)
- Fix GainStress never accumulating: was reading player.PlayerData.metadata.stress
  (never written back) and writing to the state bag, so stress always reset to
  the last `amount`. Now reads and writes the statebag exclusively.
- Unify RelieveStress/GainStress on the statebag
- Fix exports('gainStress') / exports('relieveStress') dropping src: the
  TriggerEvent indirection shifted args (src became amount) and lost player
  context. Extracted real gainStress/relieveStress functions; net events and
  exports call them directly.

config/config.lua:
- Rename minForSpeeding -> speedThresholdBuckled and minForSpeedingUnbuckled
  -> speedThresholdUnbuckled (old names implied stress level, not a speed).
- Make blurIntensity / effectInterval tier ranges non-overlapping
  (50-59, 60-69, 70-79, 80-89, 90-100) so stress values don't match multiple
  tiers
- Document disableForLEO and note the one-shot math.random() in effectInterval
  is rolled once at resource start.

client/vehicle.lua:
- Update to renamed speedThresholdBuckled / speedThresholdUnbuckled keys.

shared/utils.lua:
- Resolve framework once at load and cache it; InitFramework() and GetPlayer()
  now read the cached value instead of calling GetResourceState three times
  per invocation.
- Switch lib.load('config.config') -> lib.require
- Bump manifest version to 2.0.2
